### PR TITLE
Reload fastd peers without restarting fastd,

### DIFF
--- a/roles/gateway/handlers/main.yml
+++ b/roles/gateway/handlers/main.yml
@@ -23,6 +23,10 @@
     state: restarted
   listen: "restart fastd"
 
+- name: reload fastd peers
+  command: pkill -HUP fastd
+  listen: "reload fastd peers"
+
 - name: restart unbound
   service:
     name: unbound

--- a/roles/gateway/tasks/fastd.yml
+++ b/roles/gateway/tasks/fastd.yml
@@ -5,7 +5,7 @@
   git:
     repo: https://github.com/pjodd/gluon-gateway-peers.git
     dest: /etc/fastd/vpn/peers
-  notify: restart fastd
+  notify: reload fastd peers
 
 - name: Generate fastd secret, if none (chmoded 0600)
   fastd_key:


### PR DESCRIPTION
I wish this could've been done with the service module and reloaded...